### PR TITLE
Clear Delay Mins EEPROM at end of Delay

### DIFF
--- a/StepLogic.ino
+++ b/StepLogic.ino
@@ -242,8 +242,12 @@ void brewStepDelay(enum StepSignal signal, struct ProgramThread *thread) {
     case STEPSIGNAL_ADVANCE:
       clearTimer(TIMER_MASH);
       setAlarm(0);
-      if (signal == STEPSIGNAL_ADVANCE)
+      if (signal == STEPSIGNAL_ADVANCE) {
         brewStepPreheat(STEPSIGNAL_INIT, thread);
+        //Clear Delay mins EEPROM setting so it will not be used next no-delay start.
+        if (getDelayMins()) 
+          setDelayMins(0);
+      }
       break;
   }
 }


### PR DESCRIPTION
Otherwise previous delay is applied when non-delayed start is selected
