### PR TITLE
Base RGBIO Output on all masks.

### DIFF
--- a/EEPROM.ino
+++ b/EEPROM.ino
@@ -342,13 +342,13 @@ void setBoilControlState(ControlState state) {
 	boilControlState = state;
 	switch (boilControlState) {
 		case CONTROLSTATE_SETPOINT:
-			pid[VS_KETTLE].SetMode(1); //Set PID to Auto
+			pid[VS_KETTLE].SetMode(AUTO);
 			break;
 		case CONTROLSTATE_OFF:
 			resetVesselHeat(VS_KETTLE);
 		case CONTROLSTATE_MANUAL:
 		case CONTROLSTATE_AUTO:
-			pid[VS_KETTLE].SetMode(0); //Set PID to Manual
+			pid[VS_KETTLE].SetMode(MANUAL);
 			break;
 	}
 }

--- a/Enum.h
+++ b/Enum.h
@@ -74,6 +74,13 @@
     OUTPUTENABLE_COUNT
   };
 
+  enum OutputStatus {
+	  OUTPUTSTATUS_DISABLED,			  //Output is disabled by an OutputEnableIndex profile
+	  OUTPUTSTATUS_FORCED,				  //Output is forced on by a profile index > OUTPUTPROFILE_USERCOUNT < OUTPUTPROFILE_SYSTEMCOUNT (non-user config profile)
+	  OUTPUTSTATUS_AUTOON,				  //Output is on by a user config profile
+	  OUTPUTSTATUS_AUTOOFF				  //Output is enabled but not currently active
+  };
+
 //Timers
 #define TIMER_MASH 0
 #define TIMER_BOIL 1

--- a/Outputs.h
+++ b/Outputs.h
@@ -105,7 +105,7 @@ class OutputSystem
   private:
   OutputBank** banks;
   byte bankCount;
-  unsigned long outputState, discreetState, profileState, profileMask[OUTPUTPROFILE_SYSTEMCOUNT], outputEnableMask[OUTPUTENABLE_COUNT];
+  unsigned long outputState, outputStateForced, outputStateDisabled, discreetState, profileState, profileMask[OUTPUTPROFILE_SYSTEMCOUNT], outputEnableMask[OUTPUTENABLE_COUNT];
   
   void addBank(OutputBank* outputBank);
   
@@ -129,6 +129,7 @@ class OutputSystem
   unsigned long getOutputStateMask(void);
   boolean getOutputEnable(byte enableIndex, byte index);
   unsigned long getOutputEnableMask(byte enableIndex);
+  OutputStatus getOutputStatus(byte outputIndex);
   void setOutputEnable(byte enableIndex, byte outputIndex, boolean enableFlag);
   void setOutputEnableMask(byte enableIndex, unsigned long enableMask);
   boolean getProfileState(byte profileIndex);

--- a/RGBIO8.cpp
+++ b/RGBIO8.cpp
@@ -38,24 +38,36 @@ void RGBIO8::update(void) {
   for (int i = 0; i < 8; i++) {
     
     RGBIO8_assignment *a = &assignments[i];
+	RGBIORecipeIndex outputRecipe = RGBIORECIPE_OFF;
+
     if (a->index != RGBIO8_UNASSIGNED) {
       //Update input
       if (isManual(i)) {
         outputs->setProfileMaskBit(OUTPUTPROFILE_RGBIO, a->index, 1);
         outputs->setOutputEnable(OUTPUTENABLE_RGBIO, a->index, 1);
-        setOutput(i, output_recipes[a->recipe_id][RGBIORECIPE_ON]);
+        
       } else if (isAuto(i)) {
         outputs->setProfileMaskBit(OUTPUTPROFILE_RGBIO, a->index, 0);
         outputs->setOutputEnable(OUTPUTENABLE_RGBIO, a->index, 1);
-        if (outputs->getOutputState(a->index))
-          setOutput(i, output_recipes[a->recipe_id][RGBIORECIPE_AUTOON]);
-        else
-          setOutput(i, output_recipes[a->recipe_id][RGBIORECIPE_AUTOOFF]);
       } else {
         outputs->setProfileMaskBit(OUTPUTPROFILE_RGBIO, a->index, 0);
         outputs->setOutputEnable(OUTPUTENABLE_RGBIO, a->index, 0);
-        setOutput(i, output_recipes[a->recipe_id][RGBIORECIPE_OFF]);
       }
+	  switch (outputs->getOutputStatus(a->index)) {
+		  case OUTPUTSTATUS_FORCED:
+			  outputRecipe = RGBIORECIPE_ON;
+			  break;
+		  case OUTPUTSTATUS_DISABLED:
+			  outputRecipe = RGBIORECIPE_OFF;
+			  break;
+		  case OUTPUTSTATUS_AUTOOFF:
+			  outputRecipe = RGBIORECIPE_AUTOOFF;
+			  break;
+		  case OUTPUTSTATUS_AUTOON:
+			  outputRecipe = RGBIORECIPE_AUTOON;
+			  break;
+	  }
+	  setOutput(i, output_recipes[a->recipe_id][outputRecipe]);
     }
   }
 }

--- a/RGBIO8.cpp
+++ b/RGBIO8.cpp
@@ -36,16 +36,15 @@ void RGBIO8::update(void) {
   
   // Update any assigned inputs
   for (int i = 0; i < 8; i++) {
-    unsigned long mask = (unsigned long) 1 << i;
     
     RGBIO8_assignment *a = &assignments[i];
     if (a->index != RGBIO8_UNASSIGNED) {
       //Update input
-      if (inputs_manual & mask) {
+      if (isManual(i)) {
         outputs->setProfileMaskBit(OUTPUTPROFILE_RGBIO, a->index, 1);
         outputs->setOutputEnable(OUTPUTENABLE_RGBIO, a->index, 1);
         setOutput(i, output_recipes[a->recipe_id][RGBIORECIPE_ON]);
-      } else if (inputs_auto & mask) {
+      } else if (isAuto(i)) {
         outputs->setProfileMaskBit(OUTPUTPROFILE_RGBIO, a->index, 0);
         outputs->setOutputEnable(OUTPUTENABLE_RGBIO, a->index, 1);
         if (outputs->getOutputState(a->index))
@@ -59,6 +58,14 @@ void RGBIO8::update(void) {
       }
     }
   }
+}
+
+boolean RGBIO8::isAuto(byte inputIndex) {
+	return (inputs_auto & (1 << inputIndex));
+}
+
+boolean RGBIO8::isManual(byte inputIndex) {
+	return (inputs_manual & (1 << inputIndex));
 }
 
 void RGBIO8::restart() {

--- a/RGBIO8.h
+++ b/RGBIO8.h
@@ -28,7 +28,7 @@ struct RGBIO8_assignment {
   byte recipe_id;
 };
 
-enum RGBIORecipeIndex {
+enum RGBIORecipeIndex : byte {
   RGBIORECIPE_OFF,
   RGBIORECIPE_AUTOOFF,
   RGBIORECIPE_AUTOON,
@@ -85,7 +85,9 @@ class RGBIO8 {
     void setIdMode(byte id_mode);
     void setAddress(byte a);
     int getInputs(void);
-    
+	boolean isAuto(byte inputIndex);
+	boolean isManual(byte inputIndex);
+
   private:
     static OutputSystem* outputs;
     static uint16_t output_recipes[RGBIO8_MAX_OUTPUT_RECIPES][RGBIORECIPE_MODECOUNT];


### PR DESCRIPTION
Fixes #20. Utilize getOutputStatus method to determine output state and apply RGBIO recipe accordingly.
