### PR TITLE
74xx595 logic and Arduino 1.6.7 compiler fix

### DIFF
--- a/LOCAL_PID_AutoTune_v0.h
+++ b/LOCAL_PID_AutoTune_v0.h
@@ -110,8 +110,8 @@ public:
   };
 
   // irrational constants
-  static const double CONST_PI          = 3.14159265358979323846;
-  static const double CONST_SQRT2_DIV_2 = 0.70710678118654752440;
+  const double CONST_PI          = 3.14159265358979323846;
+  const double CONST_SQRT2_DIV_2 = 0.70710678118654752440;
 
   // commonly used methods ***********************************************************************
   PID_ATune(double*, double*);          // * Constructor.  links the Autotune to a given PID

--- a/Outputs.cpp
+++ b/Outputs.cpp
@@ -82,14 +82,14 @@ Documentation, Forums and more information available at http://www.brewtroller.c
     #ifdef OUTPUTBANK_MUX_ENABLELOGIC
       //MUX in Reset State
       muxLatchPin.clear(); //Prepare to copy pin states
-      muxEnablePin.clear(); //Force clear of pin registers
+      muxEnablePin.set(); //Force clear (inverse) of pin registers
       muxLatchPin.set();
       delayMicroseconds(10);
       muxLatchPin.clear();
-      muxEnablePin.set(); //Disable clear
+      muxEnablePin.clear(); //Disable clear inverse)
     #else
       set(0);
-      muxEnablePin.clear();
+      muxEnablePin.set();
     #endif
   }
   
@@ -102,7 +102,10 @@ Documentation, Forums and more information available at http://www.brewtroller.c
   
     for (byte i = OUTPUTBANK_MUX_COUNT; i > 0; i--)  {
       muxClockPin.clear();
-      muxDataPin.set(outputsState & ((unsigned long)1<<(i - 1)));
+      if(outputsState & ((unsigned long)1<<(i - 1)))
+        muxDataPin.set();
+      else
+        muxDataPin.clear();
       muxClockPin.set();
       muxDataPin.clear();
     }


### PR DESCRIPTION
I had to make the following code changes to get Brewtroller to work on my board (Based on DX2).

74xx595 uses inverted logic on enable pin.

muxDataPin.set(bool) does not work (Arduino 1.6.7 problem?) Logic
expanded to use .set() and .clear() instead.

Arduino 1.6.7 does not like static const declaration.
